### PR TITLE
Remove unnecessary allocations

### DIFF
--- a/object_intern.go
+++ b/object_intern.go
@@ -560,21 +560,19 @@ func (oi *ObjectIntern) ObjBytes(objAddr uintptr) ([]byte, error) {
 	var err error
 
 	oi.RLock()
+	defer oi.RUnlock()
 
 	b, err := oi.store.Get(objAddr)
 	if err != nil {
-		oi.RUnlock()
 		return nil, err
 	}
 
 	if oi.conf.Compression != None {
 		// remove 4 trailing bytes for reference count and decompress
 		b, err = oi.decompress(b[:len(b)-4])
-		oi.RUnlock()
 		return b, err
 	}
 
-	oi.RUnlock()
 	// remove 4 trailing bytes for reference count
 	return b[:len(b)-4], nil
 }


### PR DESCRIPTION
This adds separate paths for adding objects to the object store and reduces allocations in instances where they are not needed.

Re-ran the benchmarks against master and the latest commit in this branch. I like the results a lot:

```
benchmark                                                   old ns/op      new ns/op      delta
BenchmarkAddOrGet/CompressedUintptr-10-8                    2498           2415           -3.32%
BenchmarkAddOrGet/CompressedUintptr-100-8                   26594          22655          -14.81%
BenchmarkAddOrGet/CompressedUintptr-1000-8                  268033         246025         -8.21%
BenchmarkAddOrGet/CompressedUintptr-10000-8                 2449225        2314908        -5.48%
BenchmarkAddOrGet/CompressedUintptr-100000-8                32266435       30838429       -4.43%
BenchmarkAddOrGet/CompressedUintptr-1000000-8               541250461      529692029      -2.14%
BenchmarkAddOrGet/CompressedUintptr-5000000-8               4658367912     4757259449     +2.12%
BenchmarkAddOrGet/CompressedDuplicatesUintptr-10-8          2459           2217           -9.84%
BenchmarkAddOrGet/CompressedDuplicatesUintptr-100-8         24853          23878          -3.92%
BenchmarkAddOrGet/CompressedDuplicatesUintptr-1000-8        260576         229279         -12.01%
BenchmarkAddOrGet/CompressedDuplicatesUintptr-10000-8       2881759        2501732        -13.19%
BenchmarkAddOrGet/CompressedDuplicatesUintptr-100000-8      29491916       26575229       -9.89%
BenchmarkAddOrGet/CompressedDuplicatesUintptr-1000000-8     337827489      295907882      -12.41%
BenchmarkAddOrGet/CompressedDuplicatesUintptr-5000000-8     2600559258     2607972292     +0.29%
BenchmarkAddOrGet/UnsafeUintptr-10-8                        521            339            -34.93%
BenchmarkAddOrGet/UnsafeUintptr-100-8                       5498           3413           -37.92%
BenchmarkAddOrGet/UnsafeUintptr-1000-8                      57614          37239          -35.36%
BenchmarkAddOrGet/UnsafeUintptr-10000-8                     738418         455759         -38.28%
BenchmarkAddOrGet/UnsafeUintptr-100000-8                    8334480        5573528        -33.13%
BenchmarkAddOrGet/UnsafeUintptr-1000000-8                   234665460      215707079      -8.08%
BenchmarkAddOrGet/UnsafeUintptr-5000000-8                   3655656727     3773908344     +3.23%
BenchmarkAddOrGet/UnsafeDuplicatesUintptr-10-8              579            371            -35.92%
BenchmarkAddOrGet/UnsafeDuplicatesUintptr-100-8             5525           3421           -38.08%
BenchmarkAddOrGet/UnsafeDuplicatesUintptr-1000-8            56714          35696          -37.06%
BenchmarkAddOrGet/UnsafeDuplicatesUintptr-10000-8           701969         395917         -43.60%
BenchmarkAddOrGet/UnsafeDuplicatesUintptr-100000-8          7384239        4511343        -38.91%
BenchmarkAddOrGet/UnsafeDuplicatesUintptr-1000000-8         119762333      89131263       -25.58%
BenchmarkAddOrGet/UnsafeDuplicatesUintptr-5000000-8         1642154044     1630880945     -0.69%
BenchmarkAddOrGet/SafeUintptr-10-8                          755            335            -55.63%
BenchmarkAddOrGet/SafeUintptr-100-8                         7719           3435           -55.50%
BenchmarkAddOrGet/SafeUintptr-1000-8                        79338          37882          -52.25%
BenchmarkAddOrGet/SafeUintptr-10000-8                       1018362        461677         -54.66%
BenchmarkAddOrGet/SafeUintptr-100000-8                      10985190       5614651        -48.89%
BenchmarkAddOrGet/SafeUintptr-1000000-8                     262852308      230332086      -12.37%
BenchmarkAddOrGet/SafeUintptr-5000000-8                     4078420108     4147981352     +1.71%
BenchmarkAddOrGet/SafeDuplicatesUintptr-10-8                747            374            -49.93%
BenchmarkAddOrGet/SafeDuplicatesUintptr-100-8               7361           3504           -52.40%
BenchmarkAddOrGet/SafeDuplicatesUintptr-1000-8              72882          35573          -51.19%
BenchmarkAddOrGet/SafeDuplicatesUintptr-10000-8             949702         396496         -58.25%
BenchmarkAddOrGet/SafeDuplicatesUintptr-100000-8            10195574       4564275        -55.23%
BenchmarkAddOrGet/SafeDuplicatesUintptr-1000000-8           148988176      101966893      -31.56%
BenchmarkAddOrGet/SafeDuplicatesUintptr-5000000-8           1918048045     1780009215     -7.20%
BenchmarkAddOrGet/CompressedString-10-8                     2502           2329           -6.91%
BenchmarkAddOrGet/CompressedString-100-8                    25975          24097          -7.23%
BenchmarkAddOrGet/CompressedString-1000-8                   261856         247542         -5.47%
BenchmarkAddOrGet/CompressedString-10000-8                  2722493        2610065        -4.13%
BenchmarkAddOrGet/CompressedString-100000-8                 29874853       28640206       -4.13%
BenchmarkAddOrGet/CompressedString-1000000-8                547168818      541350003      -1.06%
BenchmarkAddOrGet/CompressedString-5000000-8                4804558153     4775610047     -0.60%
BenchmarkAddOrGet/CompressedDuplicatesString-10-8           2097           1986           -5.29%
BenchmarkAddOrGet/CompressedDuplicatesString-100-8          22184          20849          -6.02%
BenchmarkAddOrGet/CompressedDuplicatesString-1000-8         223401         208227         -6.79%
BenchmarkAddOrGet/CompressedDuplicatesString-10000-8        2316030        2202877        -4.89%
BenchmarkAddOrGet/CompressedDuplicatesString-100000-8       25556126       23022276       -9.91%
BenchmarkAddOrGet/CompressedDuplicatesString-1000000-8      354516798      341081988      -3.79%
BenchmarkAddOrGet/CompressedDuplicatesString-5000000-8      2614487983     2597038503     -0.67%
BenchmarkAddOrGet/UnsafeString-10-8                         486            343            -29.42%
BenchmarkAddOrGet/UnsafeString-100-8                        5511           3537           -35.82%
BenchmarkAddOrGet/UnsafeString-1000-8                       56976          38148          -33.05%
BenchmarkAddOrGet/UnsafeString-10000-8                      709566         463676         -34.65%
BenchmarkAddOrGet/UnsafeString-100000-8                     8164479        5408504        -33.76%
BenchmarkAddOrGet/UnsafeString-1000000-8                    232045184      216375755      -6.75%
BenchmarkAddOrGet/UnsafeString-5000000-8                    3613474930     3659143842     +1.26%
BenchmarkAddOrGet/UnsafeDuplicatesString-10-8               538            387            -28.07%
BenchmarkAddOrGet/UnsafeDuplicatesString-100-8              5157           3556           -31.05%
BenchmarkAddOrGet/UnsafeDuplicatesString-1000-8             52912          35911          -32.13%
BenchmarkAddOrGet/UnsafeDuplicatesString-10000-8            642582         405057         -36.96%
BenchmarkAddOrGet/UnsafeDuplicatesString-100000-8           6983532        4505537        -35.48%
BenchmarkAddOrGet/UnsafeDuplicatesString-1000000-8          123040269      87865894       -28.59%
BenchmarkAddOrGet/UnsafeDuplicatesString-5000000-8          1640927041     1632239300     -0.53%
BenchmarkAddOrGet/SafeString-10-8                           678            362            -46.61%
BenchmarkAddOrGet/SafeString-100-8                          7426           3728           -49.80%
BenchmarkAddOrGet/SafeString-1000-8                         74685          38714          -48.16%
BenchmarkAddOrGet/SafeString-10000-8                        972071         469990         -51.65%
BenchmarkAddOrGet/SafeString-100000-8                       10781083       5501187        -48.97%
BenchmarkAddOrGet/SafeString-1000000-8                      266937656      228489858      -14.40%
BenchmarkAddOrGet/SafeString-5000000-8                      4039840768     3908703861     -3.25%
BenchmarkAddOrGet/SafeDuplicatesString-10-8                 729            402            -44.86%
BenchmarkAddOrGet/SafeDuplicatesString-100-8                7114           3709           -47.86%
BenchmarkAddOrGet/SafeDuplicatesString-1000-8               71886          37652          -47.62%
BenchmarkAddOrGet/SafeDuplicatesString-10000-8              912652         411876         -54.87%
BenchmarkAddOrGet/SafeDuplicatesString-100000-8             10042328       4591386        -54.28%
BenchmarkAddOrGet/SafeDuplicatesString-1000000-8            149052360      101391776      -31.98%
BenchmarkAddOrGet/SafeDuplicatesString-5000000-8            1941096000     1804748244     -7.02%
BenchmarkDelete/Uintptr-10-8                                11222          11152          -0.62%
BenchmarkDelete/Uintptr-100-8                               36582          36535          -0.13%
BenchmarkDelete/Uintptr-1000-8                              175284         176485         +0.69%
BenchmarkDelete/Uintptr-10000-8                             1853550        1849669        -0.21%
BenchmarkDelete/Uintptr-100000-8                            22886839       23134534       +1.08%
BenchmarkDelete/Uintptr-1000000-8                           322274242      321716262      -0.17%
BenchmarkDelete/Uintptr-5000000-8                           1911588952     1915583572     +0.21%
BenchmarkDelete/Byte-10-8                                   11765          11657          -0.92%
BenchmarkDelete/Byte-100-8                                  42225          41314          -2.16%
BenchmarkDelete/Byte-1000-8                                 219230         209528         -4.43%
BenchmarkDelete/Byte-10000-8                                2374907        2236181        -5.84%
BenchmarkDelete/Byte-100000-8                               29550558       28930697       -2.10%
BenchmarkDelete/Byte-1000000-8                              381584992      368300299      -3.48%
BenchmarkDelete/Byte-5000000-8                              2263305156     2186170880     -3.41%
BenchmarkDelete/CompressedByte-10-8                         14500          14270          -1.59%
BenchmarkDelete/CompressedByte-100-8                        68293          68452          +0.23%
BenchmarkDelete/CompressedByte-1000-8                       517549         516897         -0.13%
BenchmarkDelete/CompressedByte-10000-8                      5697815        5153056        -9.56%
BenchmarkDelete/CompressedByte-100000-8                     63714792       63646143       -0.11%
BenchmarkDelete/CompressedByte-1000000-8                    706239508      696114389      -1.43%
BenchmarkDelete/CompressedByte-5000000-8                    3800869531     3805313364     +0.12%
BenchmarkDelete/String-10-8                                 11856          11900          +0.37%
BenchmarkDelete/String-100-8                                42826          42867          +0.10%
BenchmarkDelete/String-1000-8                               212373         211967         -0.19%
BenchmarkDelete/String-10000-8                              2273575        2266940        -0.29%
BenchmarkDelete/String-100000-8                             27698482       28094507       +1.43%
BenchmarkDelete/String-1000000-8                            376481310      374796062      -0.45%
BenchmarkDelete/String-5000000-8                            2231833805     2249182376     +0.78%
BenchmarkDelete/CompressedString-10-8                       14998          15109          +0.74%
BenchmarkDelete/CompressedString-100-8                      72941          71526          -1.94%
BenchmarkDelete/CompressedString-1000-8                     619666         545930         -11.90%
BenchmarkDelete/CompressedString-10000-8                    5673166        7327816        +29.17%
BenchmarkDelete/CompressedString-100000-8                   72179611       73486465       +1.81%
BenchmarkDelete/CompressedString-1000000-8                  725056082      718898211      -0.85%
BenchmarkDelete/CompressedString-5000000-8                  4294673249     4326365943     +0.74%
BenchmarkCompressShoco-8                                    393            393            +0.00%
BenchmarkDecompressShoco-8                                  302            302            +0.00%
BenchmarkCompressNone-8                                     2.81           2.81           +0.00%
BenchmarkDecompressNone-8                                   2.86           2.86           +0.00%
BenchmarkCompressSzShoco-8                                  254            256            +0.79%
BenchmarkDecompressSzShoco-8                                250            247            -1.20%
BenchmarkCompressSzNone-8                                   2.65           2.65           +0.00%
BenchmarkDecompressSzNone-8                                 2.72           2.72           +0.00%

benchmark                                                   old allocs     new allocs     delta
BenchmarkAddOrGet/CompressedUintptr-10-8                    20             10             -50.00%
BenchmarkAddOrGet/CompressedUintptr-100-8                   200            100            -50.00%
BenchmarkAddOrGet/CompressedUintptr-1000-8                  2000           1000           -50.00%
BenchmarkAddOrGet/CompressedUintptr-10000-8                 20001          10021          -49.90%
BenchmarkAddOrGet/CompressedUintptr-100000-8                200143         102141         -48.97%
BenchmarkAddOrGet/CompressedUintptr-1000000-8               2034120        1534231        -24.58%
BenchmarkAddOrGet/CompressedUintptr-5000000-8               10305114       10305235       +0.00%
BenchmarkAddOrGet/CompressedDuplicatesUintptr-10-8          20             10             -50.00%
BenchmarkAddOrGet/CompressedDuplicatesUintptr-100-8         200            100            -50.00%
BenchmarkAddOrGet/CompressedDuplicatesUintptr-1000-8        2000           1000           -50.00%
BenchmarkAddOrGet/CompressedDuplicatesUintptr-10000-8       20000          10005          -49.98%
BenchmarkAddOrGet/CompressedDuplicatesUintptr-100000-8      200070         101069         -49.48%
BenchmarkAddOrGet/CompressedDuplicatesUintptr-1000000-8     2011517        1106963        -44.97%
BenchmarkAddOrGet/CompressedDuplicatesUintptr-5000000-8     10153608       7653057        -24.63%
BenchmarkAddOrGet/UnsafeUintptr-10-8                        10             0              -100.00%
BenchmarkAddOrGet/UnsafeUintptr-100-8                       100            0              -100.00%
BenchmarkAddOrGet/UnsafeUintptr-1000-8                      1000           0              -100.00%
BenchmarkAddOrGet/UnsafeUintptr-10000-8                     10000          3              -99.97%
BenchmarkAddOrGet/UnsafeUintptr-100000-8                    100039         540            -99.46%
BenchmarkAddOrGet/UnsafeUintptr-1000000-8                   1013867        213915         -78.90%
BenchmarkAddOrGet/UnsafeUintptr-5000000-8                   5308923        5309297        +0.01%
BenchmarkAddOrGet/UnsafeDuplicatesUintptr-10-8              10             0              -100.00%
BenchmarkAddOrGet/UnsafeDuplicatesUintptr-100-8             100            0              -100.00%
BenchmarkAddOrGet/UnsafeDuplicatesUintptr-1000-8            1000           0              -100.00%
BenchmarkAddOrGet/UnsafeDuplicatesUintptr-10000-8           10000          1              -99.99%
BenchmarkAddOrGet/UnsafeDuplicatesUintptr-100000-8          100020         179            -99.82%
BenchmarkAddOrGet/UnsafeDuplicatesUintptr-1000000-8         1003477        26730          -97.34%
BenchmarkAddOrGet/UnsafeDuplicatesUintptr-5000000-8         5152097        2652394        -48.52%
BenchmarkAddOrGet/SafeUintptr-10-8                          20             0              -100.00%
BenchmarkAddOrGet/SafeUintptr-100-8                         200            0              -100.00%
BenchmarkAddOrGet/SafeUintptr-1000-8                        2000           0              -100.00%
BenchmarkAddOrGet/SafeUintptr-10000-8                       20005          6              -99.97%
BenchmarkAddOrGet/SafeUintptr-100000-8                      201069         1035           -99.49%
BenchmarkAddOrGet/SafeUintptr-1000000-8                     2213721        413688         -81.31%
BenchmarkAddOrGet/SafeUintptr-5000000-8                     15305478       10305163       -32.67%
BenchmarkAddOrGet/SafeDuplicatesUintptr-10-8                20             0              -100.00%
BenchmarkAddOrGet/SafeDuplicatesUintptr-100-8               200            0              -100.00%
BenchmarkAddOrGet/SafeDuplicatesUintptr-1000-8              2000           0              -100.00%
BenchmarkAddOrGet/SafeDuplicatesUintptr-10000-8             20002          3              -99.99%
BenchmarkAddOrGet/SafeDuplicatesUintptr-100000-8            200535         345            -99.83%
BenchmarkAddOrGet/SafeDuplicatesUintptr-1000000-8           2053460        103468         -94.96%
BenchmarkAddOrGet/SafeDuplicatesUintptr-5000000-8           12654382       5154304        -59.27%
BenchmarkAddOrGet/CompressedString-10-8                     30             20             -33.33%
BenchmarkAddOrGet/CompressedString-100-8                    300            200            -33.33%
BenchmarkAddOrGet/CompressedString-1000-8                   3000           2000           -33.33%
BenchmarkAddOrGet/CompressedString-10000-8                  30001          20021          -33.27%
BenchmarkAddOrGet/CompressedString-100000-8                 300142         202140         -32.65%
BenchmarkAddOrGet/CompressedString-1000000-8                3034658        2534755        -16.47%
BenchmarkAddOrGet/CompressedString-5000000-8                15305235       15304733       -0.00%
BenchmarkAddOrGet/CompressedDuplicatesString-10-8           30             20             -33.33%
BenchmarkAddOrGet/CompressedDuplicatesString-100-8          300            200            -33.33%
BenchmarkAddOrGet/CompressedDuplicatesString-1000-8         3000           2000           -33.33%
BenchmarkAddOrGet/CompressedDuplicatesString-10000-8        30000          20005          -33.32%
BenchmarkAddOrGet/CompressedDuplicatesString-100000-8       300070         201071         -32.99%
BenchmarkAddOrGet/CompressedDuplicatesString-1000000-8      3011367        2178059        -27.67%
BenchmarkAddOrGet/CompressedDuplicatesString-5000000-8      15152056       12651872       -16.50%
BenchmarkAddOrGet/UnsafeString-10-8                         10             0              -100.00%
BenchmarkAddOrGet/UnsafeString-100-8                        100            0              -100.00%
BenchmarkAddOrGet/UnsafeString-1000-8                       1000           0              -100.00%
BenchmarkAddOrGet/UnsafeString-10000-8                      10000          3              -99.97%
BenchmarkAddOrGet/UnsafeString-100000-8                     100040         360            -99.64%
BenchmarkAddOrGet/UnsafeString-1000000-8                    1013925        213895         -78.90%
BenchmarkAddOrGet/UnsafeString-5000000-8                    5305159        5304971        -0.00%
BenchmarkAddOrGet/UnsafeDuplicatesString-10-8               10             0              -100.00%
BenchmarkAddOrGet/UnsafeDuplicatesString-100-8              100            0              -100.00%
BenchmarkAddOrGet/UnsafeDuplicatesString-1000-8             1000           0              -100.00%
BenchmarkAddOrGet/UnsafeDuplicatesString-10000-8            10000          1              -99.99%
BenchmarkAddOrGet/UnsafeDuplicatesString-100000-8           100019         180            -99.82%
BenchmarkAddOrGet/UnsafeDuplicatesString-1000000-8          1003475        26726          -97.34%
BenchmarkAddOrGet/UnsafeDuplicatesString-5000000-8          5152191        2652382        -48.52%
BenchmarkAddOrGet/SafeString-10-8                           20             0              -100.00%
BenchmarkAddOrGet/SafeString-100-8                          200            0              -100.00%
BenchmarkAddOrGet/SafeString-1000-8                         2000           0              -100.00%
BenchmarkAddOrGet/SafeString-10000-8                        20005          6              -99.97%
BenchmarkAddOrGet/SafeString-100000-8                       200535         690            -99.66%
BenchmarkAddOrGet/SafeString-1000000-8                      2213866        413871         -81.31%
BenchmarkAddOrGet/SafeString-5000000-8                      15307378       10307808       -32.66%
BenchmarkAddOrGet/SafeDuplicatesString-10-8                 20             0              -100.00%
BenchmarkAddOrGet/SafeDuplicatesString-100-8                200            0              -100.00%
BenchmarkAddOrGet/SafeDuplicatesString-1000-8               2000           0              -100.00%
BenchmarkAddOrGet/SafeDuplicatesString-10000-8              20002          3              -99.99%
BenchmarkAddOrGet/SafeDuplicatesString-100000-8             200535         345            -99.83%
BenchmarkAddOrGet/SafeDuplicatesString-1000000-8            2053455        103451         -94.96%
BenchmarkAddOrGet/SafeDuplicatesString-5000000-8            12653857       5154262        -59.27%
BenchmarkDelete/Uintptr-10-8                                6              6              +0.00%
BenchmarkDelete/Uintptr-100-8                               23             23             +0.00%
BenchmarkDelete/Uintptr-1000-8                              120            120            +0.00%
BenchmarkDelete/Uintptr-10000-8                             1110           1110           +0.00%
BenchmarkDelete/Uintptr-100000-8                            11013          11025          +0.11%
BenchmarkDelete/Uintptr-1000000-8                           110123         109956         -0.15%
BenchmarkDelete/Uintptr-5000000-8                           550939         549925         -0.18%
BenchmarkDelete/Byte-10-8                                   7              6              -14.29%
BenchmarkDelete/Byte-100-8                                  33             23             -30.30%
BenchmarkDelete/Byte-1000-8                                 220            120            -45.45%
BenchmarkDelete/Byte-10000-8                                2114           1111           -47.45%
BenchmarkDelete/Byte-100000-8                               20970          10994          -47.57%
BenchmarkDelete/Byte-1000000-8                              210451         110079         -47.69%
BenchmarkDelete/Byte-5000000-8                              1049856        551097         -47.51%
BenchmarkDelete/CompressedByte-10-8                         18             17             -5.56%
BenchmarkDelete/CompressedByte-100-8                        141            131            -7.09%
BenchmarkDelete/CompressedByte-1000-8                       1319           1219           -7.58%
BenchmarkDelete/CompressedByte-10000-8                      13097          12115          -7.50%
BenchmarkDelete/CompressedByte-100000-8                     131100         120992         -7.71%
BenchmarkDelete/CompressedByte-1000000-8                    1310205        1210350        -7.62%
BenchmarkDelete/CompressedByte-5000000-8                    6548390        6049457        -7.62%
BenchmarkDelete/String-10-8                                 6              6              +0.00%
BenchmarkDelete/String-100-8                                23             23             +0.00%
BenchmarkDelete/String-1000-8                               120            120            +0.00%
BenchmarkDelete/String-10000-8                              1110           1110           +0.00%
BenchmarkDelete/String-100000-8                             11019          11004          -0.14%
BenchmarkDelete/String-1000000-8                            110035         110049         +0.01%
BenchmarkDelete/String-5000000-8                            551166         549413         -0.32%
BenchmarkDelete/CompressedString-10-8                       28             27             -3.57%
BenchmarkDelete/CompressedString-100-8                      241            231            -4.15%
BenchmarkDelete/CompressedString-1000-8                     2319           2219           -4.31%
BenchmarkDelete/CompressedString-10000-8                    23114          22104          -4.37%
BenchmarkDelete/CompressedString-100000-8                   231054         221008         -4.35%
BenchmarkDelete/CompressedString-1000000-8                  2309875        2210140        -4.32%
BenchmarkDelete/CompressedString-5000000-8                  11551054       11052117       -4.32%
BenchmarkCompressShoco-8                                    1              1              +0.00%
BenchmarkDecompressShoco-8                                  1              1              +0.00%
BenchmarkCompressNone-8                                     0              0              +0.00%
BenchmarkDecompressNone-8                                   0              0              +0.00%
BenchmarkCompressSzShoco-8                                  3              3              +0.00%
BenchmarkDecompressSzShoco-8                                3              3              +0.00%
BenchmarkCompressSzNone-8                                   0              0              +0.00%
BenchmarkDecompressSzNone-8                                 0              0              +0.00%

benchmark                                                   old bytes      new bytes      delta
BenchmarkAddOrGet/CompressedUintptr-10-8                    1160           1120           -3.45%
BenchmarkAddOrGet/CompressedUintptr-100-8                   11722          11200          -4.45%
BenchmarkAddOrGet/CompressedUintptr-1000-8                  119745         112013         -6.46%
BenchmarkAddOrGet/CompressedUintptr-10000-8                 1201678        1122137        -6.62%
BenchmarkAddOrGet/CompressedUintptr-100000-8                12169921       11385749       -6.44%
BenchmarkAddOrGet/CompressedUintptr-1000000-8               189707152      182131352      -3.99%
BenchmarkAddOrGet/CompressedUintptr-5000000-8               1148997336     1149016024     +0.00%
BenchmarkAddOrGet/CompressedDuplicatesUintptr-10-8          1160           1120           -3.45%
BenchmarkAddOrGet/CompressedDuplicatesUintptr-100-8         11722          11200          -4.45%
BenchmarkAddOrGet/CompressedDuplicatesUintptr-1000-8        119724         112013         -6.44%
BenchmarkAddOrGet/CompressedDuplicatesUintptr-10000-8       1200711        1120532        -6.68%
BenchmarkAddOrGet/CompressedDuplicatesUintptr-100000-8      12081603       11289630       -6.56%
BenchmarkAddOrGet/CompressedDuplicatesUintptr-1000000-8     148065925      126051324      -14.87%
BenchmarkAddOrGet/CompressedDuplicatesUintptr-5000000-8     900230600      860472424      -4.42%
BenchmarkAddOrGet/UnsafeUintptr-10-8                        80             0              -100.00%
BenchmarkAddOrGet/UnsafeUintptr-100-8                       800            0              -100.00%
BenchmarkAddOrGet/UnsafeUintptr-1000-8                      8004           2              -99.98%
BenchmarkAddOrGet/UnsafeUintptr-10000-8                     152497         384            -99.75%
BenchmarkAddOrGet/UnsafeUintptr-100000-8                    1632852        48904          -97.00%
BenchmarkAddOrGet/UnsafeUintptr-1000000-8                   40997830       28215964       -31.18%
BenchmarkAddOrGet/UnsafeUintptr-5000000-8                   583487272      602541240      +3.27%
BenchmarkAddOrGet/UnsafeDuplicatesUintptr-10-8              80             0              -100.00%
BenchmarkAddOrGet/UnsafeDuplicatesUintptr-100-8             800            0              -100.00%
BenchmarkAddOrGet/UnsafeDuplicatesUintptr-1000-8            8002           1              -99.99%
BenchmarkAddOrGet/UnsafeDuplicatesUintptr-10000-8           152236         193            -99.87%
BenchmarkAddOrGet/UnsafeDuplicatesUintptr-100000-8          1612514        16275          -98.99%
BenchmarkAddOrGet/UnsafeDuplicatesUintptr-1000000-8         22243118       3523608        -84.16%
BenchmarkAddOrGet/UnsafeDuplicatesUintptr-5000000-8         330999016      291064600      -12.06%
BenchmarkAddOrGet/SafeUintptr-10-8                          160            0              -100.00%
BenchmarkAddOrGet/SafeUintptr-100-8                         1600           0              -100.00%
BenchmarkAddOrGet/SafeUintptr-1000-8                        16007          2              -99.99%
BenchmarkAddOrGet/SafeUintptr-10000-8                       304644         431            -99.86%
BenchmarkAddOrGet/SafeUintptr-100000-8                      3297383        56776          -98.28%
BenchmarkAddOrGet/SafeUintptr-1000000-8                     63394496       31405289       -50.46%
BenchmarkAddOrGet/SafeUintptr-5000000-8                     822718712      662741144      -19.44%
BenchmarkAddOrGet/SafeDuplicatesUintptr-10-8                160            0              -100.00%
BenchmarkAddOrGet/SafeDuplicatesUintptr-100-8               1600           0              -100.00%
BenchmarkAddOrGet/SafeDuplicatesUintptr-1000-8              16003          1              -99.99%
BenchmarkAddOrGet/SafeDuplicatesUintptr-10000-8             304308         217            -99.93%
BenchmarkAddOrGet/SafeDuplicatesUintptr-100000-8            3240762        18990          -99.41%
BenchmarkAddOrGet/SafeDuplicatesUintptr-1000000-8           39843536       7862164        -80.27%
BenchmarkAddOrGet/SafeDuplicatesUintptr-5000000-8           491749016      331755192      -32.54%
BenchmarkAddOrGet/CompressedString-10-8                     1280           1200           -6.25%
BenchmarkAddOrGet/CompressedString-100-8                    12800          12000          -6.25%
BenchmarkAddOrGet/CompressedString-1000-8                   128012         120013         -6.25%
BenchmarkAddOrGet/CompressedString-10000-8                  1281981        1273998        -0.62%
BenchmarkAddOrGet/CompressedString-100000-8                 13683839       12955754       -5.32%
BenchmarkAddOrGet/CompressedString-1000000-8                205771784      197872424      -3.84%
BenchmarkAddOrGet/CompressedString-5000000-8                1259708168     1258839192     -0.07%
BenchmarkAddOrGet/CompressedDuplicatesString-10-8           1280           1200           -6.25%
BenchmarkAddOrGet/CompressedDuplicatesString-100-8          12800          12000          -6.25%
BenchmarkAddOrGet/CompressedDuplicatesString-1000-8         128006         120006         -6.25%
BenchmarkAddOrGet/CompressedDuplicatesString-10000-8        1280496        1272444        -0.63%
BenchmarkAddOrGet/CompressedDuplicatesString-100000-8       13601772       12873313       -5.36%
BenchmarkAddOrGet/CompressedDuplicatesString-1000000-8      163942672      151210272      -7.77%
BenchmarkAddOrGet/CompressedDuplicatesString-5000000-8      970215000      930219720      -4.12%
BenchmarkAddOrGet/UnsafeString-10-8                         80             0              -100.00%
BenchmarkAddOrGet/UnsafeString-100-8                        800            0              -100.00%
BenchmarkAddOrGet/UnsafeString-1000-8                       8004           2              -99.98%
BenchmarkAddOrGet/UnsafeString-10000-8                      152499         385            -99.75%
BenchmarkAddOrGet/UnsafeString-100000-8                     1632886        32631          -98.00%
BenchmarkAddOrGet/UnsafeString-1000000-8                    41009894       28210054       -31.21%
BenchmarkAddOrGet/UnsafeString-5000000-8                    582369800      582330696      -0.01%
BenchmarkAddOrGet/UnsafeDuplicatesString-10-8               80             0              -100.00%
BenchmarkAddOrGet/UnsafeDuplicatesString-100-8              800            0              -100.00%
BenchmarkAddOrGet/UnsafeDuplicatesString-1000-8             8002           1              -99.99%
BenchmarkAddOrGet/UnsafeDuplicatesString-10000-8            152150         192            -99.87%
BenchmarkAddOrGet/UnsafeDuplicatesString-100000-8           1612393        16335          -98.99%
BenchmarkAddOrGet/UnsafeDuplicatesString-1000000-8          22242785       3522734        -84.16%
BenchmarkAddOrGet/UnsafeDuplicatesString-5000000-8          331018568      291097064      -12.06%
BenchmarkAddOrGet/SafeString-10-8                           160            0              -100.00%
BenchmarkAddOrGet/SafeString-100-8                          1600           0              -100.00%
BenchmarkAddOrGet/SafeString-1000-8                         16007          2              -99.99%
BenchmarkAddOrGet/SafeString-10000-8                        304645         431            -99.86%
BenchmarkAddOrGet/SafeString-100000-8                       3240741        38024          -98.83%
BenchmarkAddOrGet/SafeString-1000000-8                      63436192       31455366       -50.41%
BenchmarkAddOrGet/SafeString-5000000-8                      823319832      663450104      -19.42%
BenchmarkAddOrGet/SafeDuplicatesString-10-8                 160            0              -100.00%
BenchmarkAddOrGet/SafeDuplicatesString-100-8                1600           0              -100.00%
BenchmarkAddOrGet/SafeDuplicatesString-1000-8               16003          1              -99.99%
BenchmarkAddOrGet/SafeDuplicatesString-10000-8              304306         217            -99.93%
BenchmarkAddOrGet/SafeDuplicatesString-100000-8             3240827        19026          -99.41%
BenchmarkAddOrGet/SafeDuplicatesString-1000000-8            39842569       7858625        -80.28%
BenchmarkAddOrGet/SafeDuplicatesString-5000000-8            491633656      331743496      -32.52%
BenchmarkDelete/Uintptr-10-8                                111            112            +0.90%
BenchmarkDelete/Uintptr-100-8                               977            979            +0.20%
BenchmarkDelete/Uintptr-1000-8                              11064          11072          +0.07%
BenchmarkDelete/Uintptr-10000-8                             111977         111941         -0.03%
BenchmarkDelete/Uintptr-100000-8                            1121360        1122259        +0.08%
BenchmarkDelete/Uintptr-1000000-8                           11222182       11203590       -0.17%
BenchmarkDelete/Uintptr-5000000-8                           56153456       56039632       -0.20%
BenchmarkDelete/Byte-10-8                                   208            112            -46.15%
BenchmarkDelete/Byte-100-8                                  1939           976            -49.66%
BenchmarkDelete/Byte-1000-8                                 22140          11057          -50.06%
BenchmarkDelete/Byte-10000-8                                224240         112075         -50.02%
BenchmarkDelete/Byte-100000-8                               2235894        1118831        -49.96%
BenchmarkDelete/Byte-1000000-8                              22458794       11217141       -50.05%
BenchmarkDelete/Byte-5000000-8                              112031600      56171168       -49.86%
BenchmarkDelete/CompressedByte-10-8                         1391           1312           -5.68%
BenchmarkDelete/CompressedByte-100-8                        13779          12977          -5.82%
BenchmarkDelete/CompressedByte-1000-8                       139060         131044         -5.76%
BenchmarkDelete/CompressedByte-10000-8                      1390837        1312469        -5.63%
BenchmarkDelete/CompressedByte-100000-8                     13928982       13119091       -5.81%
BenchmarkDelete/CompressedByte-1000000-8                    139227264      131242304      -5.74%
BenchmarkDelete/CompressedByte-5000000-8                    695902720      655996496      -5.73%
BenchmarkDelete/String-10-8                                 111            111            +0.00%
BenchmarkDelete/String-100-8                                978            977            -0.10%
BenchmarkDelete/String-1000-8                               11070          11070          +0.00%
BenchmarkDelete/String-10000-8                              111972         111972         +0.00%
BenchmarkDelete/String-100000-8                             1121584        1119876        -0.15%
BenchmarkDelete/String-1000000-8                            11212213       11213829       +0.01%
BenchmarkDelete/String-5000000-8                            56178912       55982576       -0.35%
BenchmarkDelete/CompressedString-10-8                       1649           1569           -4.85%
BenchmarkDelete/CompressedString-100-8                      16288          15502          -4.83%
BenchmarkDelete/CompressedString-1000-8                     169659         161684         -4.70%
BenchmarkDelete/CompressedString-10000-8                    1704375        1623168        -4.76%
BenchmarkDelete/CompressedString-100000-8                   17261604       16456327       -4.67%
BenchmarkDelete/CompressedString-1000000-8                  174209536      166239160      -4.58%
BenchmarkDelete/CompressedString-5000000-8                  871966688      832144176      -4.57%
BenchmarkCompressShoco-8                                    112            112            +0.00%
BenchmarkDecompressShoco-8                                  112            112            +0.00%
BenchmarkCompressNone-8                                     0              0              +0.00%
BenchmarkDecompressNone-8                                   0              0              +0.00%
BenchmarkCompressSzShoco-8                                  136            136            +0.00%
BenchmarkDecompressSzShoco-8                                136            136            +0.00%
BenchmarkCompressSzNone-8                                   0              0              +0.00%
BenchmarkDecompressSzNone-8                                 0              0              +0.00%
```